### PR TITLE
view assembly and view genome annotation methods

### DIFF
--- a/ui/narrative/methods/view_assembly/display.yaml
+++ b/ui/narrative/methods/view_assembly/display.yaml
@@ -1,0 +1,46 @@
+#
+# Define basic display information
+#
+name     : View Assembly
+subtitle : |
+    View and explore an Assembly object in your workspace. [5]
+tooltip  : |
+    View and explore an Assembly in your workspace. [5]
+
+screenshots :
+    []
+
+#
+# Define the set of other narrative methods that should be suggested to the user.
+#
+suggestions :
+    apps:
+        related :
+            []
+        next :
+            []
+    methods:
+        related :
+            []
+        next :
+            []
+
+#
+# Configure the display and description of the parameters
+#
+parameters :
+    param0 :
+        ui-name : |
+            Assembly
+        short-hint : |
+            select the assembly you want to view [5.1]
+        long-hint  : |
+            select the assembly you want to view [5.1]
+
+
+description : |
+    View and explore an Assembly object in your workspace. [5]
+
+
+technical-description : |
+    View and explore an Assembly object in your workspace. [5]

--- a/ui/narrative/methods/view_assembly/spec.json
+++ b/ui/narrative/methods/view_assembly/spec.json
@@ -1,0 +1,37 @@
+{
+  "name" : "View Assembly",
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : ["viewers"],
+  "widgets" : {
+    "input" : null,
+    "output" : "kbaseGenomeAnnotationAssembly"
+  },
+  "parameters" : [ {
+    "id" : "param0",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseGenomeAnnotations.Assembly" ]
+    }
+  } ],
+  "behavior" : {
+    "none" : {
+      "output_mapping" : [
+        {
+          "input_parameter": "param0",
+          "target_property": "objNameOrId"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "wsNameOrId"
+        }
+      ]
+    }
+  }
+}

--- a/ui/narrative/methods/view_genome_annotation/display.yaml
+++ b/ui/narrative/methods/view_genome_annotation/display.yaml
@@ -1,0 +1,46 @@
+#
+# Define basic display information
+#
+name     : View Genome Annotation
+subtitle : |
+    View and explore an Genome Annotation object in your workspace. [5]
+tooltip  : |
+    View and explore an Genome Annotation in your workspace. [5]
+
+screenshots :
+    []
+
+#
+# Define the set of other narrative methods that should be suggested to the user.
+#
+suggestions :
+    apps:
+        related :
+            []
+        next :
+            []
+    methods:
+        related :
+            []
+        next :
+            []
+
+#
+# Configure the display and description of the parameters
+#
+parameters :
+    param0 :
+        ui-name : |
+            Genome Annotation
+        short-hint : |
+            select the genome annotation you want to view [5.1]
+        long-hint  : |
+            select the genome annotation you want to view [5.1]
+
+
+description : |
+    View and explore an Genome Annotation object in your workspace. [5]
+
+
+technical-description : |
+    View and explore an Genome Annotation object in your workspace. [5]

--- a/ui/narrative/methods/view_genome_annotation/spec.json
+++ b/ui/narrative/methods/view_genome_annotation/spec.json
@@ -1,0 +1,37 @@
+{
+  "name" : "View Genome Annotation",
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : ["viewers"],
+  "widgets" : {
+    "input" : null,
+    "output" : "kbaseGenomeAnnotation"
+  },
+  "parameters" : [ {
+    "id" : "param0",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "kbaseGenomeAnnotations.GenomeAnnotation" ]
+    }
+  } ],
+  "behavior" : {
+    "none" : {
+      "output_mapping" : [
+        {
+          "input_parameter": "param0",
+          "target_property": "objNameOrId"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "wsNameOrId"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
For lack of an SDK module to put these things into, could we just merge into NarrativeViewers for now to get it moving? Presumably, the code can also be tossed into the relevant SDK module as desired.
