### PR TITLE
Removed metabolic modeling category

### DIFF
--- a/ui/narrative/methods/view_growth_curves/spec.json
+++ b/ui/narrative/methods/view_growth_curves/spec.json
@@ -2,9 +2,9 @@
       "name" : "View Growth Curves",
       "ver" : "1.0.10",
       "authors" : [ ],
-      "contact" : "help@kbase.us",
+      "contact" : "http://kbase.us/contact-us/",
       "visble" : true,
-      "categories" : ["active","metabolic_modeling"],
+      "categories" : ["active"],
       "app_type" : "viewer",
       "widgets" : {
         "input" : "kbaseGrowthCurvesInput",


### PR DESCRIPTION
This isn't a metabolic modeling category. @roy said that there's no appropriate category for it right now, and we should just let it appear in Unknown.

(Of course, this change won't visibly take effect until this app is redeployed, which is unlikely to happen soon.)