### PR TITLE
Add WS type

### DIFF
--- a/ui/narrative/methods/view_generic_matrix/spec.json
+++ b/ui/narrative/methods/view_generic_matrix/spec.json
@@ -16,7 +16,10 @@
     "advanced" : false,
     "allow_multiple" : false,
     "default_values" : [ "" ],
-    "field_type" : "text"
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseMatrices" ]
+    }
   } ],
   "behavior" : {
     "none" : {


### PR DESCRIPTION
Apparently valid_ws_types is apparently not optional for narrative viewers (UPA logic expects it)