### PR TITLE
Use new kbaseAlignment viewer

### DIFF
--- a/ui/narrative/methods/view_rnaseq_alignment/spec.json
+++ b/ui/narrative/methods/view_rnaseq_alignment/spec.json
@@ -8,7 +8,7 @@
   "app_type" : "viewer",
   "widgets" : {
     "input" : null,
-    "output" : "kbaseRNASeqPieNew"
+    "output" : "kbaseAlignment"
   },
   "parameters" : [ {
     "id" : "param0",


### PR DESCRIPTION
Dropping the old kbaseRNASeqPieNew (which don't even make pie charts) in favor of a dedicated, cleaner viewer