### PR TITLE
[PTV-1905] modify Media and ProteinStructures viewers to use service widget with a test service

### DIFF
--- a/ui/narrative/methods/view_media/display.yaml
+++ b/ui/narrative/methods/view_media/display.yaml
@@ -29,15 +29,8 @@ suggestions :
 #
 # Configure the display and description of the parameters
 #
-parameters :
-    param0 :
-        ui-name : |
-            Media ID
-        short-hint : |
-            Media type [9.1]
-        long-hint  : |
-            Media type [9.1]
-
+parameters : {}
+    
 
 description : |
     Bring up a detailed view of a Media set within the narrative. [9]

--- a/ui/narrative/methods/view_media/spec.json
+++ b/ui/narrative/methods/view_media/spec.json
@@ -1,6 +1,6 @@
 {
   "name" : "View Media",
-  "ver" : "1.0.0",
+  "ver" : "2.0.0",
   "authors" : [ ],
   "contact" : "https://www.kbase.us/support/",
   "visible" : true,
@@ -8,33 +8,19 @@
   "app_type" : "viewer",
   "widgets" : {
     "input" : null,
-    "output" : "kbaseTabTable"
+    "output" : "ServiceWidget"
   },
-  "parameters" : [ {
-    "id" : "param0",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseBiochem.Media" ]
-    }
-  } ],
+  "parameters" : [ ],
   "behavior" : {
     "none" : {
       "output_mapping" : [
         {
-          "constant_value": "KBaseBiochem.Media",
-          "target_property": "type"
+          "constant_value": "eapearsonWidgetTest10",
+          "target_property": "service_module_name"
         },
         {
-          "input_parameter": "param0",
-          "target_property": "obj"
-        },
-        {
-          "narrative_system_variable": "workspace",
-          "target_property": "ws"
+          "constant_value": "media_viewer_py",
+          "target_property": "widget_name"
         }
       ]
     }

--- a/ui/narrative/methods/view_proteinstructures/display.yaml
+++ b/ui/narrative/methods/view_proteinstructures/display.yaml
@@ -29,14 +29,7 @@ suggestions :
 #
 # Configure the display and description of the parameters
 #
-parameters :
-    proteinstructures :
-        ui-name : |
-            ProteinStructures
-        short-hint : |
-            select the ProteinStructures you want to view
-        long-hint  : |
-            select the ProteinStructures you want to view
+parameters : {}
 
 
 description : |

--- a/ui/narrative/methods/view_proteinstructures/spec.json
+++ b/ui/narrative/methods/view_proteinstructures/spec.json
@@ -1,6 +1,6 @@
 {
   "name" : "View ProteinStructures",
-  "ver" : "1.0.0",
+  "ver" : "2.0.0",
   "authors" : [ ],
   "contact" : "https://www.kbase.us/support/",
   "visible" : true,
@@ -8,29 +8,19 @@
   "app_type" : "viewer",
   "widgets" : {
     "input" : null,
-    "output" : "KBaseProteinStructuresView"
+    "output" : "ServiceWidget"
   },
-  "parameters" : [ {
-    "id" : "proteinstructures",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseStructure.ProteinStructures" ]
-    }
-  } ],
+  "parameters" : [ ],
   "behavior" : {
     "none" : {
       "output_mapping" : [
         {
-          "input_parameter": "proteinstructures",
-          "target_property": "id"
+          "constant_value": "eapearsonWidgetTest10",
+          "target_property": "service_module_name"
         },
         {
-          "narrative_system_variable": "workspace_id",
-          "target_property": "ws"
+          "constant_value": "protein_structures_viewer",
+          "target_property": "widget_name"
         }
       ]
     }


### PR DESCRIPTION
This set of changes modifies the ui configuration (`display.yaml` and `spec.json`) for the Media (view_media) and ProteinStuctures (view_proteinstructures) viewers to be compatible with the in-development dynamic service widget format.
The dynamic service specified is for testing and evaluation of service widget features, and happens to have an implementation for both of these types.
The idea is to merge in these viewer changes, and then to redeploy just the `dev` version tag in CI, so that a deployment of the Narrative will be able to use these viewers by selecting the `dev` tag. Narrative changes I've been working on, and will be in a PR shortly, adds support to data viewer handling (just for service widgets though) to honor the version tag set in the app panel.
The risk of accidentally releasing these changes or having them conflict with an urgent viewer deployment change, seems rather low, given the low rate of change in this repo.
Ultimately, these changes can be rolled back, or if these types will be be migrated to service widgets eventually, at least modified to point to the supported dynamic service that will be developed to contain the viewers.

When deploying the dynamic service, we _could_ just deploy from commits in the branch/PR, so that a "rollback" of the changes is simply closing the PR, deleting the branch, and redeploying from the master branch.